### PR TITLE
Compilation fixes/cleanup for ms compiler

### DIFF
--- a/include/varintdecode.h
+++ b/include/varintdecode.h
@@ -1,9 +1,7 @@
-
 #ifndef VARINTDECODE_H_
 #define VARINTDECODE_H_
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-#include <stdint.h>// please use a C99-compatible compiler
+
+#include <stdint.h>
 #include <stddef.h>
 
 #if defined(__cplusplus)
@@ -33,7 +31,7 @@ int masked_vbyte_search_delta(const uint8_t *in, uint64_t length, uint32_t prev,
                     uint32_t key, uint32_t *presult);
 
 #if defined(__cplusplus)
-};
+}
 #endif
 
 #endif /* VARINTDECODE_H_ */

--- a/include/varintencode.h
+++ b/include/varintencode.h
@@ -1,8 +1,7 @@
-
 #ifndef VARINTENCODE_H_
 #define VARINTENCODE_H_
 
-#include <stdint.h> // please use a C99-compatible compiler
+#include <stdint.h>
 #include <stddef.h>
 
 #if defined(__cplusplus)
@@ -11,16 +10,16 @@ extern "C" {
 
 // Encode an array of a given length read from in to bout in varint format.
 // Returns the number of bytes written.
-size_t vbyte_encode(uint32_t *in, size_t length, uint8_t *bout);
+size_t vbyte_encode(const uint32_t *in, size_t length, uint8_t *bout);
 
 // Encode an array of a given length read from in to bout in varint format with differential
 // coding starting at value prev. (Setting prev to 0 is a good default.)
 //
 // Returns the number of bytes written.
-size_t vbyte_encode_delta(uint32_t *in, size_t length, uint8_t *bout, uint32_t prev);
+size_t vbyte_encode_delta(const uint32_t *in, size_t length, uint8_t *bout, uint32_t prev);
 
 #if defined(__cplusplus)
-};
+}
 #endif
 
 #endif /* VARINTENCODE_H_ */

--- a/src/varintdecode.c
+++ b/src/varintdecode.c
@@ -1,7 +1,5 @@
 #include "varintdecode.h"
 
-#include <x86intrin.h>
-
 #if defined(_MSC_VER)
 #define ALIGNED(x) __declspec(align(x))
 #else
@@ -23,6 +21,7 @@
         } \
     } while (0)
 #else
+#include <x86intrin.h>
 # define SIMDCOMP_CTZ(result, mask) \
     result = __builtin_ctz(mask)
 #endif
@@ -32,7 +31,7 @@ typedef struct index_bytes_consumed {
 	uint8_t bytes_consumed;
 } index_bytes_consumed;
 
-static index_bytes_consumed combined_lookup[] ALIGNED(0x1000) = {
+static const index_bytes_consumed ALIGNED(0x1000) combined_lookup[] = {
 	{0, 6},    {32, 7},   {16, 7},   {118, 6},  {8, 7},    {48, 8},   {82, 6},
 	{160, 5},  {4, 7},    {40, 8},   {24, 8},   {127, 7},  {70, 6},   {109, 7},
 	{148, 5},  {165, 6},  {2, 7},    {36, 8},   {20, 8},   {121, 7},  {12, 8},
@@ -622,7 +621,7 @@ static index_bytes_consumed combined_lookup[] ALIGNED(0x1000) = {
 };
 
 
-static const int8_t vectorsrawbytes[] ALIGNED(0x1000) = {
+static const int8_t ALIGNED(0x1000) vectorsrawbytes[] = {
 	0,  -1, 4,  -1, 1,  -1, 5,  -1, 2,  -1, -1, -1, 3,  -1, -1, -1,  // 0
 	0,  -1, 4,  -1, 1,  -1, 5,  6,  2,  -1, -1, -1, 3,  -1, -1, -1,  // 1
 	0,  -1, 4,  5,  1,  -1, 6,  -1, 2,  -1, -1, -1, 3,  -1, -1, -1,  // 2
@@ -1777,7 +1776,7 @@ size_t masked_vbyte_decode_fromcompressedsize_delta(const uint8_t* in, uint32_t*
 
 
 
-static int8_t shuffle_mask_bytes1[16 * 16 ]  ALIGNED(16) = {
+static const int8_t ALIGNED(16) shuffle_mask_bytes1[16 * 16 ]  = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     4, 5, 6, 7, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -2039,7 +2038,7 @@ int masked_vbyte_search_delta(const uint8_t *in, uint64_t length, uint32_t prev,
     return length;
 }
 
-static int8_t shuffle_mask_bytes2[16 * 16 ] ALIGNED(16) = {
+static const int8_t ALIGNED(16) shuffle_mask_bytes2[16 * 16 ] = {
     0,1,2,3,0,0,0,0,0,0,0,0,0,0,0,0,
     4,5,6,7,0,0,0,0,0,0,0,0,0,0,0,0,
     8,9,10,11,0,0,0,0,0,0,0,0,0,0,0,0,

--- a/src/varintencode.c
+++ b/src/varintencode.c
@@ -1,7 +1,7 @@
 #include "varintencode.h"
 
 
-size_t vbyte_encode_delta(uint32_t *in, size_t length, uint8_t *bout, uint32_t prev) {
+size_t vbyte_encode_delta(const uint32_t *in, size_t length, uint8_t *bout, uint32_t prev) {
 	uint8_t *initbout = bout;
 	for (size_t k = 0; k < length; ++k) {
 		const uint32_t val = in[k] - prev;
@@ -46,7 +46,7 @@ size_t vbyte_encode_delta(uint32_t *in, size_t length, uint8_t *bout, uint32_t p
 	return bout - initbout;
 }
 
-size_t vbyte_encode(uint32_t *in, size_t length, uint8_t *bout) {
+size_t vbyte_encode(const uint32_t *in, size_t length, uint8_t *bout) {
 	uint8_t *initbout = bout;
 	for (size_t k = 0; k < length; ++k) {
 		const uint32_t val = in[k];


### PR DESCRIPTION
 + remove unnecessary __STDC_FORMAT_MACROS/inttypes.h
 + change input to const in vbyte_encode/vbyte_encode_delta
 + move x86intrin.h include outside of _MSC_VER block (not supported by MS compiler)
 + reposition ALIGNED macro to fix compilation error with MS compiler
 + change some tables to const